### PR TITLE
Add visibility option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bitrise*
 .gows.user.yml
+_tmp

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,9 +7,9 @@ app:
     - A_SECRET_PARAM: $A_SECRET_PARAM
     # If you want to share this step into a StepLib
     - BITRISE_STEP_ID: lambdatest-upload
-    - BITRISE_STEP_VERSION: "4.0.0"
-    - BITRISE_STEP_GIT_CLONE_URL: https://github.com/LambdaTest/bitrise-step-lambdatest-upload.git
-    - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/LambdaTest/bitrise-steplib.git
+    - BITRISE_STEP_VERSION: "4.1.0"
+    - BITRISE_STEP_GIT_CLONE_URL: https://github.com/jelwood-zoomcare/bitrise-step-lambdatest-upload.git
+    - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:jelwood-zoomcare/bitrise-steplib.git
 
 workflows:
   test:
@@ -36,6 +36,7 @@ workflows:
             - lambdatest_username: $LAMBDATEST_USERNAME
             - lambdatest_access_key: $LAMBDATEST_ACCESS_KEY
             - app_name: $APP_NAME
+            - app_visibility: $APP_VISIBILITY
             - custom_id: $CUSTOM_ID
       - script:
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,8 +8,8 @@ app:
     # If you want to share this step into a StepLib
     - BITRISE_STEP_ID: lambdatest-upload
     - BITRISE_STEP_VERSION: "4.1.0"
-    - BITRISE_STEP_GIT_CLONE_URL: https://github.com/jelwood-zoomcare/bitrise-step-lambdatest-upload.git
-    - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:jelwood-zoomcare/bitrise-steplib.git
+    - BITRISE_STEP_GIT_CLONE_URL: https://github.com/LambdaTest/bitrise-step-lambdatest-upload.git
+    - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/LambdaTest/bitrise-steplib.git
 
 workflows:
   test:

--- a/step.sh
+++ b/step.sh
@@ -5,18 +5,20 @@ set -o pipefail
 
 UPLOAD_PATH=${upload_path}
 APP_NAME=${app_name}
+APP_VISIBILITY=${app_visibility}
 CUSTOM_ID=${custom_id}
 
 if [ -z "${UPLOAD_PATH##*http*}" ]; then
     curl --location --request POST "https://$lambdatest_username:$lambdatest_access_key@manual-api.lambdatest.com/app/upload/realDevice" \
     --header "Content-Type: application/json" \
-    --data-raw '{"url":"'$UPLOAD_PATH'","custom_id":"'$custom_id'", "name":"'$APP_NAME'"}' \
+    --data-raw '{"url":"'$UPLOAD_PATH'","custom_id":"'$custom_id'","name":"'$APP_NAME'","visibility":"'$APP_VISIBILITY'"}' \
     -o ".upload-app-response.json"
 else
     curl --location --request POST "https://$lambdatest_username:$lambdatest_access_key@manual-api.lambdatest.com/app/upload/realDevice" \
     --form "name=$APP_NAME" \
     --form "custom_id=$CUSTOM_ID" \
     --form "appFile=@"$UPLOAD_PATH"" \
+    --form "visibility=$APP_VISIBILITY" \
     -o ".upload-app-response.json"
 fi
 

--- a/step.yml
+++ b/step.yml
@@ -45,8 +45,8 @@ inputs:
         The app file you want to upload to LambdaTest, usually `$BITRISE\_APK\_PATH`
         or `$BITRISE\_IPA\_PATH`
       title: A Bitrise generated APK or IPA path
-    
-  - lambdatest_username: 
+
+  - lambdatest_username:
     opts:
       description: |
         The username you use to log into your LambdaTest account
@@ -54,7 +54,7 @@ inputs:
       is_sensitive: true
       summary: Your LambdaTest username
       title: LambdaTest username
-  - lambdatest_access_key: 
+  - lambdatest_access_key:
     opts:
       description: |
         The access key you use to log into your LambdaTest account
@@ -74,7 +74,14 @@ inputs:
       is_required: false
       summary: Custom Id to run your automation on the same app instead of remembering app_url
       title: Custom Id
-      
+  - app_visibility: "individual"
+    opts:
+      description: |
+        Whether to show the app to just the account that uploaded the file ("individual"), or to everyone ("team")
+      is_required: false
+      summary: App visibility on LambdaTest
+      title: App Visibility
+
 outputs:
   - LAMBDATEST_APP_URL:
     opts:


### PR DESCRIPTION
According to https://www.lambdatest.com/support/docs/app-testing-apis there is a visibility option that can be set, I would like to be able to automatically set my uploads as accessible by my whole team instead of defaulting to individual.